### PR TITLE
Add errno.h header

### DIFF
--- a/srcs/tester.h
+++ b/srcs/tester.h
@@ -6,7 +6,7 @@
 /*   By: vlugand- <vlugand-@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/11/05 16:45:10 by user42            #+#    #+#             */
-/*   Updated: 2020/11/20 16:34:57 by vlugand-         ###   ########.fr       */
+/*   Updated: 2021/01/11 18:29:13 by ykoh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 # include <sys/stat.h>
 # include <fcntl.h>
 # include <stdio.h>
+# include <errno.h>
 
 # define RED "\033[0;31m"
 # define GREEN "\033[0;32m"


### PR DESCRIPTION
Thank you for providing the awesome libasm tester.
When I use it, I found some error, report it.

## Error command
```shell
bash test_libasm.sh
```

## error_log
```
srcs/test_ft_2.c:51:62: error: use of undeclared identifier 'errno'
        printf("Your output: Error no %i - %s\n\n", errno, strerror(errno));
                                                                    ^
srcs/test_ft_2.c:51:46: error: use of undeclared identifier 'errno'
        printf("Your output: Error no %i - %s\n\n", errno, strerror(errno));
                                                    ^
srcs/test_ft_2.c:52:9: error: use of undeclared identifier 'errno'
        ret1 = errno;
               ^
srcs/test_ft_2.c:54:62: error: use of undeclared identifier 'errno'
        printf("Expected   : Error no %i - %s\n\n", errno, strerror(errno));
                                                                    ^
srcs/test_ft_2.c:54:46: error: use of undeclared identifier 'errno'
        printf("Expected   : Error no %i - %s\n\n", errno, strerror(errno));
                                                    ^
srcs/test_ft_2.c:55:14: error: use of undeclared identifier 'errno'
        if (ret1 == errno && fd1 > 0 && fd2 > 0)
                    ^
srcs/test_ft_2.c:74:62: error: use of undeclared identifier 'errno'
        printf("Your output: Error no %i - %s\n\n", errno, strerror(errno));
                                                                    ^
srcs/test_ft_2.c:74:46: error: use of undeclared identifier 'errno'
        printf("Your output: Error no %i - %s\n\n", errno, strerror(errno));
                                                    ^
srcs/test_ft_2.c:75:9: error: use of undeclared identifier 'errno'
        ret1 = errno;
               ^
srcs/test_ft_2.c:77:62: error: use of undeclared identifier 'errno'
        printf("Expected   : Error no %i - %s\n\n", errno, strerror(errno));
                                                                    ^
srcs/test_ft_2.c:77:46: error: use of undeclared identifier 'errno'
        printf("Expected   : Error no %i - %s\n\n", errno, strerror(errno));
                                                    ^
srcs/test_ft_2.c:78:23: error: use of undeclared identifier 'errno'
        int_diff_check(ret1, errno);
                             ^
12 errors generated.
```

## Solution
Add errno header to tester.h file.
https://github.com/valentinllpz/Libasm_Unit_Tests/commit/69a817381c60eb3ad410445ccb055a7d0c110468